### PR TITLE
Changed staticfiles to work on Linux 2 images

### DIFF
--- a/.ebextensions/options.config
+++ b/.ebextensions/options.config
@@ -8,5 +8,5 @@ option_settings:
     NEW_SIGNUP_TOPIC: '`{"Ref" : "NewSignupTopic"}`'
   aws:elasticbeanstalk:container:nodejs:
     ProxyServer: nginx
-  aws:elasticbeanstalk:container:nodejs:staticfiles:
-    /static: /static
+  aws:elasticbeanstalk:environment:proxy:staticfiles:
+    /static: static


### PR DESCRIPTION
*Issue #: Unable to deploy #18

*Description of changes:*

The current configuration assumes that you are using Amazon Linux AMI (pre-Amazon Linux 2), but the current default image is "Amazon Linux 2" and the static file parameter has changed. This patch updates the config to the default and would help lots of people trying this demo app for the first time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
