### PR TITLE
Use new namespace for static files for Amazon Linux 2

### DIFF
--- a/.ebextensions/options.config
+++ b/.ebextensions/options.config
@@ -8,5 +8,5 @@ option_settings:
     NEW_SIGNUP_TOPIC: '`{"Ref" : "NewSignupTopic"}`'
   aws:elasticbeanstalk:container:nodejs:
     ProxyServer: nginx
-  aws:elasticbeanstalk:container:nodejs:staticfiles:
+  aws:elasticbeanstalk:environment:proxy:staticfiles:
     /static: /static


### PR DESCRIPTION
The sample code stopped to work a few weeks ago.
This modification also requires an update for the CloudFormation template used to deploy sample for AWS X-Ray.

This:
===========
      PlatformArn:
        'Fn::Join':
          - ':'
          - - 'arn:aws:elasticbeanstalk'
            - Ref: 'AWS::Region'
            - ':platform/Node.js running on 64bit Amazon Linux'
===========

should be replaced with this:

===========
     SolutionStackName: '64bit Amazon Linux 2 v5.5.6 running Node.js 16'
===========

